### PR TITLE
fixes to make project compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,15 @@ CXXFLAGS:= -g -O -Wall -Wuninitialized -Wno-unknown-pragmas -Wshadow -Wstrict-pr
 CXXFLAGS+= -Wimplicit -Wundef -Wreorder -Wwrite-strings -Wnon-virtual-dtor -Wno-multichar
 CXXFLAGS+= $(SDL_CFLAGS) $(DEFINES)
 
-SRCS = bank.cpp file.cpp engine.cpp logic.cpp mixer.cpp resource.cpp sdlstub.cpp \
-	serializer.cpp sfxplayer.cpp staticres.cpp util.cpp video.cpp main.cpp
+SRCS = bank.cpp file.cpp engine.cpp mixer.cpp resource.cpp parts.cpp vm.cpp \
+	serializer.cpp sfxplayer.cpp staticres.cpp util.cpp video.cpp main.cpp sysImplementation.cpp
+
+# logic.cpp sdlstub.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 DEPS = $(SRCS:.cpp=.d)
 
-raw: $(OBJS)
+game: $(OBJS)
 	$(CXX) $(LDFLAGS) -o $@ $(OBJS) $(SDL_LIBS) -lz
 
 .cpp.o:

--- a/sfxplayer.cpp
+++ b/sfxplayer.cpp
@@ -50,7 +50,7 @@ void SfxPlayer::loadSfxModule(uint16 resNum, uint16 delay, uint8 pos) {
 
 	MemEntry *me = &res->_memList[resNum];
 
-	if (me->state == 1 && me->type == Resource::ResType::RT_MUSIC) {
+	if (me->state == 1 && me->type == Resource::RT_MUSIC) {
 		_resNum = resNum;
 		memset(&_sfxMod, 0, sizeof(SfxModule));
 		_sfxMod.curOrder = pos;

--- a/sysImplementation.cpp
+++ b/sysImplementation.cpp
@@ -116,7 +116,7 @@ void SDLStub::destroy() {
 
 void SDLStub::setPalette(uint8 start, uint8 numEnties, const uint8 *buf) {
 
-	assert(s + n <= 16);
+	assert(start + numEnties <= 16);
 
 	for (int i = start; i < start + numEnties; ++i) {
 


### PR DESCRIPTION
Hello, the Makefile had a few issues that I have fixed. Namely it referenced non-existing files and did not include needed files.

Also Resource::ResType::RT_MUSIC is illegal in c++ since ResType is an enum. The proper way is simply Resource::RT_MUSIC.
