### PR TITLE
For better code legibility, use MEMENTRY_STATE_* instead of plain intege...

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -196,7 +196,7 @@ void Resource::loadMarkedAsNeeded() {
 			loadDestination = _scriptCurPtr;
 			if (me->size > _vidBakPtr - _scriptCurPtr) {
 				warning("Resource::load() not enough memory");
-				me->state = 0;
+				me->state = MEMENTRY_STATE_NOT_NEEDED;
 				continue;
 			}
 		}
@@ -210,7 +210,7 @@ void Resource::loadMarkedAsNeeded() {
 			readBank(me, loadDestination);
 			if(me->type == RT_POLY_ANIM) {
 				video->copyPagePtr(_vidCurPtr);
-				me->state = 0;
+				me->state = MEMENTRY_STATE_NOT_NEEDED;
 			} else {
 				me->bufPtr = loadDestination;
 				me->state = MEMENTRY_STATE_LOADED;
@@ -239,7 +239,7 @@ void Resource::invalidateAll() {
 	MemEntry *me = _memList;
 	uint16_t i = _numMemList;
 	while (i--) {
-		me->state = 0;
+		me->state = MEMENTRY_STATE_NOT_NEEDED;
 		++me;
 	}
 	_scriptCurPtr = _memPtrStart;
@@ -294,14 +294,14 @@ void Resource::setupPart(uint16_t partId) {
 	// Mark all resources as located on harddrive.
 	invalidateAll();
 
-	_memList[paletteIndex].state = 2;
-	_memList[codeIndex].state = 2;
-	_memList[videoCinematicIndex].state = 2;
+	_memList[paletteIndex].state = MEMENTRY_STATE_LOAD_ME;
+	_memList[codeIndex].state = MEMENTRY_STATE_LOAD_ME;
+	_memList[videoCinematicIndex].state = MEMENTRY_STATE_LOAD_ME;
 
 	// This is probably a cinematic or a non interactive part of the game.
 	// Player and enemy polygons are not needed.
 	if (video2Index != MEMLIST_PART_NONE) 
-		_memList[video2Index].state = 2;
+		_memList[video2Index].state = MEMENTRY_STATE_LOAD_ME;
 	
 
 	loadMarkedAsNeeded();
@@ -357,7 +357,7 @@ void Resource::saveOrLoad(Serializer &ser) {
 			MemEntry *me = 0;
 			uint16_t num = _numMemList;
 			while (num--) {
-				if (it->state == 1 && it->bufPtr == q) {
+				if (it->state == MEMENTRY_STATE_LOADED && it->bufPtr == q) {
 					me = it;
 				}
 				++it;
@@ -395,7 +395,7 @@ void Resource::saveOrLoad(Serializer &ser) {
 			MemEntry *me = &_memList[*p++];
 			readBank(me, q);
 			me->bufPtr = q;
-			me->state = 1;
+			me->state = MEMENTRY_STATE_LOADED;
 			q += me->size;
 		}
 	}	

--- a/resource.h
+++ b/resource.h
@@ -47,8 +47,13 @@ struct MemEntry {
 	uint16_t size; // 0x12
 };
 /*
-     Note: state is not a boolean, it can have value 0, 1 or 2. WTF ?!
+     Note: state is not a boolean, it can have value 0, 1, 2 or 255, respectively meaning:
+      0:NOT_NEEDED
+      1:LOADED
+      2:LOAD_ME
+      255:END_OF_MEMLIST
 
+    See MEMENTRY_STATE_* #defines above.
 */
 
 struct Serializer;

--- a/sfxplayer.cpp
+++ b/sfxplayer.cpp
@@ -50,7 +50,7 @@ void SfxPlayer::loadSfxModule(uint16_t resNum, uint16_t delay, uint8_t pos) {
 
 	MemEntry *me = &res->_memList[resNum];
 
-	if (me->state == 1 && me->type == Resource::RT_MUSIC) {
+	if (me->state == MEMENTRY_STATE_LOADED && me->type == Resource::RT_MUSIC) {
 		_resNum = resNum;
 		memset(&_sfxMod, 0, sizeof(SfxModule));
 		_sfxMod.curOrder = pos;
@@ -83,7 +83,7 @@ void SfxPlayer::prepareInstruments(const uint8_t *p) {
 		if (resNum != 0) {
 			ins->volume = READ_BE_UINT16(p);
 			MemEntry *me = &res->_memList[resNum];
-			if (me->state == 1 && me->type == 0) {
+			if (me->state == MEMENTRY_STATE_LOADED && me->type == Resource::RT_SOUND) {
 				ins->data = me->bufPtr;
 				memset(ins->data + 8, 0, 4);
 				debug(DBG_SND, "Loaded instrument 0x%X n=%d volume=%d", resNum, i, ins->volume);

--- a/vm.cpp
+++ b/vm.cpp
@@ -680,7 +680,7 @@ void VirtualMachine::snd_playSound(uint16_t resNum, uint8_t freq, uint8_t vol, u
 	
 	MemEntry *me = &res->_memList[resNum];
 
-	if (me->state != 1)
+	if (me->state != MEMENTRY_STATE_LOADED)
 		return;
 
 	


### PR DESCRIPTION
...rs anywhere we deal with the mementry state field.

Also using type==Resource::RT_SOUND instead of type==0 in sfxplayer.cpp.
